### PR TITLE
Update patches and base versions

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,8 +20,8 @@
     "require": {
         "drupal/focal_point": "^1.0@beta",
         "drupal/crop": "^1.3",
-        "drupal/entity_browser": "^1.3",
-        "drupal/entity_embed": "^1.0@beta",
+        "drupal/entity_browser": "^1.8",
+        "drupal/entity_embed": "^1.3",
         "drupal/inline_entity_form": "^1.0@beta",
         "drupal/media_entity_document": "^1.1",
         "drupal/media_entity_image": "^1.2",
@@ -31,22 +31,14 @@
         "drupal/video_embed_media": "^1.5",
         "drupal/views_infinite_scroll": "^1.5"
     },
-    "extra": {
-        "patches": {
-            "drupal/entity_browser": {
-                "2865928 - The View widget should filter based on field settings":
-                "https://www.drupal.org/files/issues/entity-browser-view-context-2865928-14.patch",
-                "2877751 - Inform users how many items they can add to a field that uses an entity browser":
-                "https://www.drupal.org/files/issues/2877751-17.patch"
-            },
-            "drupal/entity_embed": {
-                "2832504 - Send the CKEditor instance ID to the embed.preview route":
-                "https://www.drupal.org/files/issues/2832504-2.patch"
-            },
-            "drupal/embed": {
-                "2824110 - Allow site-builders to use a non-managed file as button icon":
-                "https://www.drupal.org/files/issues/allow-non-managed-button-icon-files-2824110-1.patch"
-            }
+    "patches": {
+        "drupal/entity_embed": {
+            "2832504 - Send the CKEditor instance ID to the embed.preview route":
+            "https://www.drupal.org/files/issues/2019-12-16/embed-allow-non-managed-button-icon-files--2824110-35.patch"
+        },
+        "drupal/embed": {
+            "2824110 - Allow site-builders to use a non-managed file as button icon":
+            "https://www.drupal.org/files/issues/2019-12-16/embed-allow-non-managed-button-icon-files--2824110-35.patch"
         }
     }
 }


### PR DESCRIPTION
Gets rid of lots of broken patches, including one that breaks recent versions of the embed module.

We should probably lock any versions of module that are getting patches.