### PR TITLE
Added requirements for d9 compatibility to info.yml files

### DIFF
--- a/bene_media.info.yml
+++ b/bene_media.info.yml
@@ -1,5 +1,6 @@
 name: Bene Media
 core: 8.x
+core_version_requirement: ^8 || ^9
 type: module
 description: 'Media support for Bene.'
 package: Bene

--- a/modules/bene_media_document/bene_media_document.info.yml
+++ b/modules/bene_media_document/bene_media_document.info.yml
@@ -1,5 +1,6 @@
 name: 'Media Document'
 core: 8.x
+core_version_requirement: ^8 || ^9
 type: module
 description: 'Deprecated: Locally hosted document support for Bene Media. Uninstall this module, it will disappear in future iterations.'
 package: Bene

--- a/modules/bene_media_file/bene_media_file.info.yml
+++ b/modules/bene_media_file/bene_media_file.info.yml
@@ -1,5 +1,6 @@
 name: 'Bene Media File'
 core: 8.x
+core_version_requirement: ^8 || ^9
 type: module
 package: Bene
 description: 'File support for Bene Media.'

--- a/modules/bene_media_instagram/bene_media_instagram.info.yml
+++ b/modules/bene_media_instagram/bene_media_instagram.info.yml
@@ -1,5 +1,6 @@
 name: 'Bene Media Instagram'
 core: 8.x
+core_version_requirement: ^8 || ^9
 type: module
 description: 'Instagram support for Bene Media.'
 package: Bene

--- a/modules/bene_media_twitter/bene_media_twitter.info.yml
+++ b/modules/bene_media_twitter/bene_media_twitter.info.yml
@@ -1,5 +1,6 @@
 name: 'Bene Media Twitter'
 core: 8.x
+core_version_requirement: ^8 || ^9
 type: module
 description: 'Twitter support for Bene Media.'
 package: Bene

--- a/modules/bene_media_video/bene_media_video.info.yml
+++ b/modules/bene_media_video/bene_media_video.info.yml
@@ -1,5 +1,6 @@
 name: 'Bene Media Video'
 core: 8.x
+core_version_requirement: ^8 || ^9
 type: module
 package: Bene
 description: 'Video support for Bene Media.'


### PR DESCRIPTION
Hi @mariacha @unclegcb. This is to address the d9 issues with FEAM and I simply added the core_version_requirement key to the info.ymls where errors were being thrown by the update status checker. These include:

- bene_media/bene_media.info.yml
- bene_media/modules/bene_media_document/bene_media_document.info.yml
- bene_media/modules/bene_media_file/bene_media_file.info.yml
- bene_media/modules/bene_media_instagram/bene_media_instagram.info.yml
- bene_media/modules/bene_media_twitter/bene_media_twitter.info.yml
- bene_media/modules/bene_media_video/bene_media_video.info.yml